### PR TITLE
Restrict querying to specified schemas

### DIFF
--- a/cycquery/base.py
+++ b/cycquery/base.py
@@ -89,6 +89,8 @@ class DatasetQuerier:
     database : str, optional
         The name of the database or the path to the database file (for SQLite),
         by default empty.
+    schemas : Union[str, List[str]], optional
+        The schema(s) to query, by default None.
 
     Notes
     -----
@@ -109,6 +111,7 @@ class DatasetQuerier:
         host: str = "",
         port: Optional[int] = None,
         database: str = "",
+        schemas: Optional[List[str]] = None,
     ) -> None:
         config = DatasetQuerierConfig(
             database=database,
@@ -117,6 +120,7 @@ class DatasetQuerier:
             dbms=dbms,
             host=host,
             port=port,
+            schemas=schemas,
         )
         self.db = Database(config)
         if not self.db.is_connected:
@@ -133,7 +137,15 @@ class DatasetQuerier:
             List of schema names.
 
         """
-        return list(self.db.inspector.get_schema_names())
+        all_schemas = list(self.db.inspector.get_schema_names())
+        if self.db.config.schemas is None:
+            return all_schemas
+        if isinstance(self.db.config.schemas, str):
+            schemas_to_use = [self.db.config.schemas]
+        else:
+            schemas_to_use = self.db.config.schemas
+
+        return [schema for schema in all_schemas if schema in schemas_to_use]
 
     def list_tables(self, schema_name: Optional[str] = None) -> List[str]:
         """List table methods that can be queried using the database.

--- a/tests/cycquery/test_base.py
+++ b/tests/cycquery/test_base.py
@@ -14,7 +14,7 @@ def test_dataset_querier():
         user="postgres",
         password="pwd",
     )
-    assert len(querier.list_tables()) == 69
+    assert len(querier.list_tables()) == 66
     assert len(querier.list_schemas()) == 4
     assert len(querier.list_tables(schema_name="cdm_synthea10")) == 44
     visit_occrrence_columns = querier.list_columns("cdm_synthea10", "visit_occurrence")

--- a/tests/cycquery/test_mimiciv.py
+++ b/tests/cycquery/test_mimiciv.py
@@ -15,8 +15,11 @@ def test_mimiciv_querier():
         database="mimiciv-2.0",
         user="postgres",
         password="pwd",
+        schemas=["mimiciv_hosp", "mimiciv_icu"],
     )
 
+    schemas = querier.list_schemas()
+    assert schemas == ["mimiciv_hosp", "mimiciv_icu"]
     patients = querier.patients().run(limit=10)
     assert len(patients) == 10
     assert "anchor_year_difference" in patients


### PR DESCRIPTION
# PR Type ([Feature | Fix | Documentation | Test])
Feature/enhancement

## Short Description
- Add option restrict querier to read user specified schemas
- Is useful when user doesn't want to read all schemas or has limited access

## Tests Added
...
